### PR TITLE
admin token check for crisis

### DIFF
--- a/x/crisis/handler_test.go
+++ b/x/crisis/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -37,7 +38,11 @@ func createTestApp() (*simapp.SimApp, sdk.Context, []sdk.AccAddress) {
 	feePool.CommunityPool = sdk.NewDecCoinsFromCoins(sdk.NewCoins(constantFee)...)
 	app.DistrKeeper.SetFeePool(ctx, feePool)
 
-	addrs := simapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(10000))
+	addrs := simapp.AddTestAddrs(app, ctx, 2, sdk.NewInt(10000))
+
+	adminCoins := sdk.NewCoins(sdk.NewCoin("cudosAdmin", sdk.OneInt()))
+	app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, adminCoins)
+	app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addrs[0], adminCoins)
 
 	return app, ctx, addrs
 }
@@ -45,6 +50,7 @@ func createTestApp() (*simapp.SimApp, sdk.Context, []sdk.AccAddress) {
 func TestHandleMsgVerifyInvariant(t *testing.T) {
 	app, ctx, addrs := createTestApp()
 	sender := addrs[0]
+	senderNotAdmin := addrs[1]
 
 	cases := []struct {
 		name           string
@@ -54,6 +60,7 @@ func TestHandleMsgVerifyInvariant(t *testing.T) {
 		{"bad invariant route", types.NewMsgVerifyInvariant(sender, testModuleName, "route-that-doesnt-exist"), "fail"},
 		{"invariant broken", types.NewMsgVerifyInvariant(sender, testModuleName, dummyRouteWhichFails.Route), "panic"},
 		{"invariant passing", types.NewMsgVerifyInvariant(sender, testModuleName, dummyRouteWhichPasses.Route), "pass"},
+		{"not admin token holder", types.NewMsgVerifyInvariant(senderNotAdmin, testModuleName, dummyRouteWhichPasses.Route), "fail"},
 		{"invalid msg", testdata.NewTestMsg(), "fail"},
 	}
 

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -9,6 +9,8 @@ import (
 
 var _ types.MsgServer = Keeper{}
 
+var adminTokenDenom = "cudosAdmin"
+
 func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvariant) (*types.MsgVerifyInvariantResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	constantFee := sdk.NewCoins(k.GetConstantFee(ctx))
@@ -17,6 +19,13 @@ func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvar
 	if err != nil {
 		return nil, err
 	}
+
+	adminCoin := k.supplyKeeper.GetBalance(ctx, sender, adminTokenDenom)
+
+	if adminCoin.Amount.Equal(sdk.ZeroInt()) {
+		return nil, types.ErrAdminOnly
+	}
+
 	if err := k.SendCoinsFromAccountToFeeCollector(ctx, sender, constantFee); err != nil {
 		return nil, err
 	}

--- a/x/crisis/types/errors.go
+++ b/x/crisis/types/errors.go
@@ -8,4 +8,5 @@ import (
 var (
 	ErrNoSender         = sdkerrors.Register(ModuleName, 2, "sender address is empty")
 	ErrUnknownInvariant = sdkerrors.Register(ModuleName, 3, "unknown invariant")
+	ErrAdminOnly        = sdkerrors.Register(ModuleName, 4, "sender has no admin tokens")
 )

--- a/x/crisis/types/expected_keepers.go
+++ b/x/crisis/types/expected_keepers.go
@@ -7,4 +7,5 @@ import (
 // SupplyKeeper defines the expected supply keeper (noalias)
 type SupplyKeeper interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	GetBalance(ctx sdk.Context, acc sdk.AccAddress, denom string) sdk.Coin
 }


### PR DESCRIPTION
Closes: [CUDOS-732]

Added check in msg_server so that if the sender doesn't have cudosAdmin tokens, the message fails.